### PR TITLE
Enable Docker image download from CI pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Save Docker image
         run: docker save quantum-risk | gzip > quantum-risk.tar.gz
       - name: Upload image artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: quantum-risk-image
           path: quantum-risk.tar.gz

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,3 +23,10 @@ jobs:
         run: pytest
       - name: Build Docker image
         run: docker build -t quantum-risk .
+      - name: Save Docker image
+        run: docker save quantum-risk | gzip > quantum-risk.tar.gz
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: quantum-risk-image
+          path: quantum-risk.tar.gz


### PR DESCRIPTION
## Summary
- publish the Docker image generated in CI as an artifact

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68595cf6b5488328bc5846d4cd80da40